### PR TITLE
Group linter deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,14 @@
       "major": {
         "automerge": false
       },
+      "packageRules": [
+        {
+          "packagePatterns": [
+            "(^|.*-)(eslint|prettier|stylelint)(-.*|$)"
+          ],
+          "groupName": "linters"
+        }
+      ],
       "rangeStrategy": "bump",
       "schedule": "before 3am on the first day of the month"
     }


### PR DESCRIPTION
This will group anything matching the following the regex pattern under the name "linters":

```
(^|.*-)(eslint|prettier|stylelint)(-.*|$)
```